### PR TITLE
Added parameter binding to prevent AQL injection.

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -20,7 +20,7 @@ const shortQuery = `
             RETURN m
         )
     }
-  `
+`
 
 // TestQueryRun runs tests on the Query Run method.
 func TestQueryRun(t *testing.T) {
@@ -57,6 +57,18 @@ func TestQueryRun(t *testing.T) {
 	result, err = db.Run(NewQuery(""))
 	r.NoError(err)
 	a.Equal("[{},{}]", string(result))
+
+	q := NewQuery(`
+	    FOR d
+	    IN documents
+	    FILTER d._key == @key
+	    RETURN d
+	    `)
+	q.Bind("key", 1000)
+	result, err = db.Run(q)
+
+	r.NoError(err)
+	a.Equal("[{}]", string(result))
 
 	httpmock.RegisterResponder("POST", "http://arangodb:8000/_db/dbName/_api/cursor",
 		httpmock.NewStringResponder(500, `{"error": true, "errorMessage": "error !"}`))


### PR DESCRIPTION
Current query implementation allows [AQL injection](https://docs.arangodb.com/cookbook/AvoidingInjection.html), like 
```go
    key := "1 || true INSERT { foo: 'bar' } IN nodes"
    q := arangolite.NewQuery(`
       FOR n
       IN nodes
       FILTER n._key == %s
       RETURN n
    `, key)
    result, err := db.Run(q)
```
This reading request will insert a new document.
To prevent this I added a Bind function to Query:
```go
    key := 1234
    q := arangolite.NewQuery(`
        FOR n
        IN nodes
        FILTER n._key == @key
       RETURN n
    `)
    q.Bind("key", key)
    result, err := db.Run(q)
 ```

