### PR TITLE
Add LIKE filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ JSON:
         {"birthPlace": ["Paris", "Los Angeles"]},
         {"age": {"gte": 18}}
       ]
+    },
+    {
+      "like": {
+        "text": "lastName",
+        "search": "R%",
+        "case_insensitive": true
+      }
     }
   ]
   },
@@ -240,7 +247,7 @@ AQL:
 ```
 LIMIT 1, 2
 SORT var.age DESC, var.money ASC
-FILTER var.firstName == 'Pierre' && (var.birthPlace IN ['Paris', 'Los Angeles'] || var.age >= 18)
+FILTER var.firstName == 'Pierre' && (var.birthPlace IN ['Paris', 'Los Angeles'] || var.age >= 18) && LIKE(var.lastName, 'R%', true)
 ```
 
 ### Operators
@@ -251,6 +258,7 @@ FILTER var.firstName == 'Pierre' && (var.birthPlace IN ['Paris', 'Los Angeles'] 
 - `gt`, `gte`: Numerical greater than (>); greater than or equal (>=).
 - `lt`, `lte`: Numerical less than (<); less than or equal (<=).
 - `eq`, `neq`: Equal (==); non equal (!=).
+- `like`: LIKE(text, search, case_insensitive) function support
 
 ### Usage
 

--- a/filters/filter_processor_test.go
+++ b/filters/filter_processor_test.go
@@ -71,6 +71,16 @@ var notWhereFilter = &Filter{
 	},
 }
 
+var likeWhereFilter = &Filter{
+	Where: []map[string]interface{}{{
+		"like": map[string]interface{}{
+			"text":             "firstName",
+			"search":           "fab%",
+			"case_insensitive": true,
+		},
+	}},
+}
+
 // TestProcessFilter runs tests on the filter processor Process method.
 func TestProcessFilter(t *testing.T) {
 	a := assert.New(t)
@@ -154,6 +164,10 @@ func TestProcessFilter(t *testing.T) {
 	for _, s := range split {
 		a.Contains(expected, s)
 	}
+
+	p, err = fp.Process(likeWhereFilter)
+	r.NoError(err)
+	a.Contains(`LIKE(var.firstName, 'fab%', true)`, p.Where)
 
 	p, err = fp.Process(&Filter{Where: []map[string]interface{}{{"var.firstName": []interface{}{"foo", map[string]interface{}{"foo": "bar"}}}}})
 	r.Error(err)


### PR DESCRIPTION
This change adds the ability to search on fields using the LIKE function provided by ArangoDB. There were no functions for precedent but I took the approach of named parameters in the condition. The text is assumed to be a document field. This approach may not work for other functions such as CONCAT but usually it makes sense that a parameter is either a field or a string.