### PR TITLE
Added regex for string substitution in transactions

### DIFF
--- a/requests/transaction.go
+++ b/requests/transaction.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
 	"strings"
 )
 
@@ -129,30 +130,8 @@ func writeQuery(buff *bytes.Buffer, aql string, resultVarName string) {
 }
 
 func toES6Template(query string) string {
-	buf := bytes.NewBuffer(nil)
-	lookingForEnd := false
-
-	for _, b := range query {
-		if lookingForEnd {
-			if b == ' ' || b == '\n' || b == ',' || b == ';' {
-				lookingForEnd = false
-				buf.WriteRune('}')
-				buf.WriteRune(b)
-				continue
-			}
-		} else {
-			if b == '@' {
-				lookingForEnd = true
-				buf.WriteString("${")
-				continue
-			}
-		}
-
-		buf.WriteRune(b)
-	}
-
-	query = buf.String()
-
-	query = strings.Replace(query, "{{.", "${", -1)
-	return strings.Replace(query, "}}", "}", -1)
+	re := regexp.MustCompile(`\{\{\.(\w+)\}\}`)
+	bindRe := regexp.MustCompile(`@(\w+)`)
+	query = bindRe.ReplaceAllString(query, `${$1}`)
+	return re.ReplaceAllString(query, `${$1}`)
 }

--- a/requests/transaction_test.go
+++ b/requests/transaction_test.go
@@ -61,6 +61,17 @@ func TestTransaction(t *testing.T) {
 			returnVar: "result",
 			output:    "{\"collections\":{\"read\":[],\"write\":[]},\"action\":\"function () { var db = require('internal').db; var documents = db._query(aqlQuery`FOR x IN documents RETURN x`).toArray(); var result = db._query(aqlQuery`FOR x IN ${documents} RETURN x`).toArray(); return result;}\"}",
 		},
+		{
+			description: "bind variables",
+			readCol:     []string{},
+			writeCol:    []string{},
+			bind:        map[string]interface{}{"city": "Los Angeles"},
+			aqls: []aqlParams{
+				{resultVar: "documents", query: `RETURN {name: @city}`},
+			},
+			returnVar: "documents",
+			output:    "{\"collections\":{\"read\":[],\"write\":[]},\"action\":\"function () { var db = require('internal').db; var city = 'Los Angeles'; var documents = db._query(aqlQuery`RETURN {name: ${city}}`).toArray(); return documents; }\"}",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This fixes an issue when creating a transaction with bind variables. If a query was written like this
`UPSERT {name: @name} ...`
The query would be translated to 
`UPSERT {name: ${name} ...`
 instead of 
`UPSERT {name: ${name}} ...`
This PR fixes that issue and creates a test for that case.