### PR TITLE
Add GetVersion request

### DIFF
--- a/requests/version.go
+++ b/requests/version.go
@@ -1,0 +1,31 @@
+package requests
+
+// GetVersion returns the server version number.
+type GetVersion struct {
+	Details bool
+}
+
+func (r *GetVersion) Path() string {
+	path := "/_api/version"
+
+	if r.Details {
+		path += "?details=true"
+	}
+
+	return path
+}
+
+func (r *GetVersion) Method() string {
+	return "GET"
+}
+
+func (r *GetVersion) Generate() []byte {
+	return []byte{}
+}
+
+type GetVersionResult struct {
+	Server  string            `json:"server"`
+	Version string            `json:"version"`
+	License string            `json:"license"`
+	Details map[string]string `json:"details"`
+}


### PR DESCRIPTION
Adds support for /_api/version (https://docs.arangodb.com/3.2/HTTP/MiscellaneousFunctions/#return-server-version).

Let me know if I should change anything.