### PR TITLE
Add AQL function requests

### DIFF
--- a/requests/aqlfunction.go
+++ b/requests/aqlfunction.go
@@ -1,0 +1,79 @@
+package requests
+
+import (
+	"encoding/json"
+)
+
+// CreateAQLFunction creates a new AQL user function.
+type CreateAQLFunction struct {
+	Name            string `json:"name"`
+	Code            string `json:"code"`
+	IsDeterministic bool   `json:"IsDeterministic"`
+}
+
+func (r *CreateAQLFunction) Path() string {
+	return "/_api/aqlfunction"
+}
+
+func (r *CreateAQLFunction) Method() string {
+	return "POST"
+}
+
+func (r *CreateAQLFunction) Generate() []byte {
+	m, _ := json.Marshal(r)
+	return m
+}
+
+// DeleteAQLFunction removes an existing AQL user function.
+type DeleteAQLFunction struct {
+	Name  string
+	Group bool
+}
+
+func (r *DeleteAQLFunction) Path() string {
+	path := "/_api/aqlfunction/" + r.Name
+
+	if r.Group {
+		path += "?group=true"
+	}
+
+	return path
+}
+
+func (r *DeleteAQLFunction) Method() string {
+	return "DELETE"
+}
+
+func (r *DeleteAQLFunction) Generate() []byte {
+	return nil
+}
+
+// GetAQLFunctions gets all registered AQL functions.
+type GetAQLFunctions struct {
+	Namespace string
+}
+
+func (r *GetAQLFunctions) Path() string {
+	path := "/_api/aqlfunction"
+
+	if r.Namespace != "" {
+		path += "?namespace=" + r.Namespace
+	}
+
+	return path
+}
+
+func (r *GetAQLFunctions) Method() string {
+	return "GET"
+}
+
+func (r *GetAQLFunctions) Generate() []byte {
+	return nil
+}
+
+type AQLFunction struct {
+	Name string `json:"name"`
+	Code string `json:"code"`
+}
+
+type GetAQLFunctionsResult []AQLFunction

--- a/requests/aqlfunction.go
+++ b/requests/aqlfunction.go
@@ -8,7 +8,7 @@ import (
 type CreateAQLFunction struct {
 	Name            string `json:"name"`
 	Code            string `json:"code"`
-	IsDeterministic bool   `json:"IsDeterministic"`
+	IsDeterministic bool   `json:"isDeterministic"`
 }
 
 func (r *CreateAQLFunction) Path() string {

--- a/senders.go
+++ b/senders.go
@@ -36,7 +36,7 @@ func (s *basicSender) Send(ctx context.Context, cli *http.Client, req *http.Requ
 	}
 
 	parsed := parsedResponse{}
-	if strings.Contains(res.Header.Get("Content-Type"), "application/json") {
+	if strings.Contains(res.Header.Get("Content-Type"), "application/json") && raw[0] != '[' {
 		if err := json.Unmarshal(raw, &parsed); err != nil {
 			return nil, errors.Wrap(err, "could not decode the json database response")
 		}

--- a/senders.go
+++ b/senders.go
@@ -36,7 +36,9 @@ func (s *basicSender) Send(ctx context.Context, cli *http.Client, req *http.Requ
 	}
 
 	parsed := parsedResponse{}
-	if strings.Contains(res.Header.Get("Content-Type"), "application/json") && raw[0] != '[' {
+	// Some API calls (such as /_api/aqlfunction) return arrays, so we have to check that
+	// the body is a JSON object before trying to unmarshal.
+	if strings.Contains(res.Header.Get("Content-Type"), "application/json") && raw[0] == '{' {
 		if err := json.Unmarshal(raw, &parsed); err != nil {
 			return nil, errors.Wrap(err, "could not decode the json database response")
 		}


### PR DESCRIPTION
Adds support for /_api/aqlfunction requests for manipulating AQL user functions (https://docs.arangodb.com/3.2/HTTP/AqlUserFunctions/).

GET /_api/aqlfunction for some reason returns an array instead of the usual wrapper object, so I added a check in senders.go to prevent it from trying to unmarshal the raw response when it's an array (`raw[0] != '['` seems like a bit of a hack, but I don't feel like it will cause any problems in practice).