### PR TITLE
Convert raw result to string on debug logging

### DIFF
--- a/log.go
+++ b/log.go
@@ -54,7 +54,7 @@ func (s *loggingSender) Send(ctx context.Context, cli *http.Client, req *http.Re
 
 	s.logger.Printf("Success in %v:\n", time.Since(now))
 	if s.verbosity == LogDebug {
-		s.logger.Println(res.raw)
+		s.logger.Println(string(res.raw))
 	}
 
 	return res, nil


### PR DESCRIPTION
Current debug log of the [`Send`](https://github.com/solher/arangolite/blob/master/log.go#L57) result looks like this:
`2017/07/24 13:31:25.806153 log.go:57: [123 34 105 100 34 58 34 110 111 100 101 115 95 99 104 97 110 103 101 115 47 50 52 51 34 44 34 116 121 112 101 34 58 34 115 107 105 112 108 105 115 116 34 44 34 102 105 101 108 100 115 34 58 91 34 114 101 118 105 115 105 111 110 34 93 44 34 117 110 105 113 117 101 34 58 102 97 108 115 101 44 34 115 112 97 114 115 101 34 58 102 97 108 115 101 44 34 105 115 78 101 119 108 121 67 114 101 97 116 101 100 34 58 102 97 108 115 101 44 34 101 114 114 111 114 34 58 102 97 108 115 101 44 34 99 111 100 101 34 58 50 48 48 125]`
