### PR TITLE
Add Logger interface as input for OptLogging

### DIFF
--- a/database.go
+++ b/database.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"runtime"
@@ -60,7 +59,7 @@ func OptHTTPClient(cli *http.Client) Option {
 }
 
 // OptLogging enables logging of the exchanges with the database.
-func OptLogging(logger *log.Logger, verbosity LogVerbosity) Option {
+func OptLogging(logger Logger, verbosity LogVerbosity) Option {
 	return func(db *Database) {
 		if logger != nil {
 			db.sender = newLoggingSender(db.sender, logger, verbosity)

--- a/database_test.go
+++ b/database_test.go
@@ -76,7 +76,8 @@ func TestConnect(t *testing.T) {
 
 // TestOptionsSend runs tests on the impact of options on the database Send method.
 func TestOptionsSend(t *testing.T) {
-	logger := log.New(ioutil.Discard, "", 0)
+	var logger arangolite.Logger
+	logger = log.New(ioutil.Discard, "", 0)
 	client, server := httpMock()
 	defer server.Close()
 	// We add a handler that only return a 200 if all the request parameters are correctly set
@@ -101,7 +102,7 @@ func TestOptionsSend(t *testing.T) {
 		dbName             string
 		endpoint           string
 		httpClient         *http.Client
-		logger             *log.Logger
+		logger             arangolite.Logger
 		verbosity          arangolite.LogVerbosity
 		// Expected results
 		testErr func(err error) bool
@@ -269,6 +270,8 @@ func TestRun(t *testing.T) {
 func TestSend(t *testing.T) {
 	client, server := httpMock()
 	defer server.Close()
+	var logger arangolite.Logger
+	logger = log.New(ioutil.Discard, "", 0)
 
 	var testCases = []struct {
 		// Case description
@@ -348,7 +351,7 @@ func TestSend(t *testing.T) {
 			server.Config.Handler = tc.dbHandler
 			db := arangolite.NewDatabase(
 				arangolite.OptHTTPClient(client),
-				arangolite.OptLogging(log.New(ioutil.Discard, "", 0), arangolite.LogDebug),
+				arangolite.OptLogging(logger, arangolite.LogDebug),
 			)
 			result, err := db.Send(ctx, requests.NewAQL(""))
 			if ok := tc.testErr(err); !ok {

--- a/log.go
+++ b/log.go
@@ -5,24 +5,29 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"time"
 )
 
+type Logger interface {
+	Print(v ...interface{})
+}
+
 // LogVerbosity is the logging verbosity.
 type LogVerbosity int
 
 const (
+	// LogNone no log output
+	LogNone LogVerbosity = iota
 	// LogSummary prints a simple summary of the exchanges with the database.
-	LogSummary LogVerbosity = iota
+	LogSummary
 	// LogDebug prints all the sent and received http requests.
 	LogDebug
 )
 
 // newLoggingSender returns a logging wrapper around a sender.
-func newLoggingSender(sender sender, logger *log.Logger, verbosity LogVerbosity) sender {
+func newLoggingSender(sender sender, logger Logger, verbosity LogVerbosity) sender {
 	return &loggingSender{
 		sender:    sender,
 		logger:    logger,
@@ -32,7 +37,7 @@ func newLoggingSender(sender sender, logger *log.Logger, verbosity LogVerbosity)
 
 type loggingSender struct {
 	sender    sender
-	logger    *log.Logger
+	logger    Logger
 	verbosity LogVerbosity
 }
 


### PR DESCRIPTION
By having an interface with the Print method only, it's possible to mock or redirect the output.

Also, add LogNone constant is it's now necessary to pass an integer that is neither 0 or 1.