### PR TITLE
Modules with version >=2 need to specify it in the go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/solher/arangolite
+module github.com/solher/arangolite/v2
 
 go 1.16


### PR DESCRIPTION
https://github.com/golang/go/wiki/Modules#semantic-import-versioning